### PR TITLE
feat(client): rename client to be more specific

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,7 +30,8 @@ func WithTransport(transport http.RoundTripper) Option {
 	}
 }
 
-// WithBaseURL sets the base URL for the client
+// WithBaseURL sets the base URL for the orchestration cluster API
+// https://docs.camunda.io/docs/next/apis-tools/camunda-api-rest/camunda-api-rest-overview/
 func WithBaseURL(baseURL url.URL) Option {
 	// Ensure path ends with /v2
 	if !strings.HasSuffix(baseURL.Path, "v2") {
@@ -51,8 +52,8 @@ func getTransport(client *http.Client) http.RoundTripper {
 	return client.Transport
 }
 
-// NewClient creates a new client with the given options
-func NewClient(opts ...Option) (*Client, error) {
+// NewOrchestrationClusterClient creates a new client with the given options
+func NewOrchestrationClusterClient(opts ...Option) (*Client, error) {
 	client := &Client{
 		httpClient: &http.Client{},
 		baseURL: url.URL{

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -22,7 +22,7 @@ func TestWithCamunda(t *testing.T) {
 	camundaURL, err := suite.CamundaEndpoint()
 	require.NoError(t, err)
 	baseURL, _ := url.Parse(camundaURL)
-	c8, err := camunda.NewClient(
+	c8, err := camunda.NewOrchestrationClusterClient(
 		camunda.WithBaseURL(*baseURL),
 	)
 	require.NoError(t, err)

--- a/examples/message/main.go
+++ b/examples/message/main.go
@@ -25,7 +25,7 @@ func main() {
 
 	fmt.Println("EXAMPLE: Config", clientID, clientSecret, tokenURL, audience, scopes, baseURL)
 
-	c8, err := camunda.NewClient(
+	c8, err := camunda.NewOrchestrationClusterClient(
 		camunda.WithBaseURL(*baseURL),
 		camunda.WithOAuth(clientID, clientSecret, tokenURL, audience, scopes),
 	)

--- a/examples/topology-request/topology.go
+++ b/examples/topology-request/topology.go
@@ -25,7 +25,7 @@ func main() {
 
 	fmt.Println("EXAMPLE: Config", clientID, clientSecret, tokenURL, audience, scopes, baseURL)
 
-	c8, err := camunda.NewClient(
+	c8, err := camunda.NewOrchestrationClusterClient(
 		camunda.WithBaseURL(*baseURL),
 		camunda.WithOAuth(clientID, clientSecret, tokenURL, audience, scopes),
 	)

--- a/internal/test_suite.go
+++ b/internal/test_suite.go
@@ -111,7 +111,7 @@ func (t topologyWaitStrategy) WaitUntilReady(ctx context.Context, target wait.St
 				return err
 			}
 
-			client, err := camunda.NewClient(camunda.WithBaseURL(*baseURL))
+			client, err := camunda.NewOrchestrationClusterClient(camunda.WithBaseURL(*baseURL))
 			if err != nil {
 				return err
 			}

--- a/message_test.go
+++ b/message_test.go
@@ -22,7 +22,7 @@ func Test_Camunda_Message(t *testing.T) {
 	camundaURL, err := suite.CamundaEndpoint()
 	require.NoError(t, err)
 	baseURL, _ := url.Parse(camundaURL)
-	c8, err := camunda.NewClient(
+	c8, err := camunda.NewOrchestrationClusterClient(
 		camunda.WithBaseURL(*baseURL),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
`Ideally, the API is extensible and we can support different API's of that are used when interacting with Camunda.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/fc174b04-7b28-4a75-b59e-cd3ddef62639" />


- this makes sure that we can extend the SDK to the different APIs such as web-modeler api, admin api etc.