### PR TITLE
refactor: make the orchestration api a dedicated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import (
     "net/url"
     "os"
     
-    "github.com/sijoma/camunda-go-sdk"
+    "github.com/sijoma/camunda-go-sdk/orchestration"
 )
 
 func main() {
@@ -40,9 +40,9 @@ func main() {
     
     fmt.Println("EXAMPLE: Config", clientID, clientSecret, tokenURL, audience, scopes, baseURL)
 
-    c8, err := camunda.NewClient(
-        camunda.WithBaseURL(*baseURL),
-        camunda.WithOAuth(clientID, clientSecret, tokenURL, audience, scopes),
+    c8, err := orchestration.NewClient(
+        orchestration.WithBaseURL(*baseURL),
+        orchestration.WithOAuth(clientID, clientSecret, tokenURL, audience, scopes),
     )
 	if err != nil {
 		fmt.Println("failed creating client", err)

--- a/examples/message/main.go
+++ b/examples/message/main.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/sijoma/camunda-go-sdk"
+	"github.com/sijoma/camunda-go-sdk/orchestration"
 )
 
 func main() {
@@ -25,16 +25,16 @@ func main() {
 
 	fmt.Println("EXAMPLE: Config", clientID, clientSecret, tokenURL, audience, scopes, baseURL)
 
-	c8, err := camunda.NewOrchestrationClusterClient(
-		camunda.WithBaseURL(*baseURL),
-		camunda.WithOAuth(clientID, clientSecret, tokenURL, audience, scopes),
+	c8, err := orchestration.NewClient(
+		orchestration.WithBaseURL(*baseURL),
+		orchestration.WithOAuth(clientID, clientSecret, tokenURL, audience, scopes),
 	)
 	if err != nil {
 		fmt.Println("failed creating client", err)
 		return
 	}
 
-	payload := camunda.MessagePublishRequest{
+	payload := orchestration.MessagePublishRequest{
 		Name:           "a name",
 		CorrelationKey: "correlation-key",
 		TimeToLive:     0,

--- a/examples/topology-request/topology.go
+++ b/examples/topology-request/topology.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"os"
 
-	"github.com/sijoma/camunda-go-sdk"
+	"github.com/sijoma/camunda-go-sdk/orchestration"
 )
 
 func main() {
@@ -25,9 +25,9 @@ func main() {
 
 	fmt.Println("EXAMPLE: Config", clientID, clientSecret, tokenURL, audience, scopes, baseURL)
 
-	c8, err := camunda.NewOrchestrationClusterClient(
-		camunda.WithBaseURL(*baseURL),
-		camunda.WithOAuth(clientID, clientSecret, tokenURL, audience, scopes),
+	c8, err := orchestration.NewClient(
+		orchestration.WithBaseURL(*baseURL),
+		orchestration.WithOAuth(clientID, clientSecret, tokenURL, audience, scopes),
 	)
 	if err != nil {
 		fmt.Println("failed creating client", err)

--- a/internal/test_suite.go
+++ b/internal/test_suite.go
@@ -11,7 +11,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	"github.com/sijoma/camunda-go-sdk"
+	"github.com/sijoma/camunda-go-sdk/orchestration"
 )
 
 type TestSuite struct {
@@ -111,7 +111,7 @@ func (t topologyWaitStrategy) WaitUntilReady(ctx context.Context, target wait.St
 				return err
 			}
 
-			client, err := camunda.NewOrchestrationClusterClient(camunda.WithBaseURL(*baseURL))
+			client, err := orchestration.NewClient(orchestration.WithBaseURL(*baseURL))
 			if err != nil {
 				return err
 			}

--- a/orchestration/auth.go
+++ b/orchestration/auth.go
@@ -1,4 +1,4 @@
-package camunda
+package orchestration
 
 import (
 	"context"

--- a/orchestration/client.go
+++ b/orchestration/client.go
@@ -1,4 +1,4 @@
-package camunda
+package orchestration
 
 import (
 	"net/http"
@@ -52,8 +52,8 @@ func getTransport(client *http.Client) http.RoundTripper {
 	return client.Transport
 }
 
-// NewOrchestrationClusterClient creates a new client with the given options
-func NewOrchestrationClusterClient(opts ...Option) (*Client, error) {
+// NewClient creates a new client with the given options
+func NewClient(opts ...Option) (*Client, error) {
 	client := &Client{
 		httpClient: &http.Client{},
 		baseURL: url.URL{

--- a/orchestration/cluster.go
+++ b/orchestration/cluster.go
@@ -1,4 +1,4 @@
-package camunda
+package orchestration
 
 import (
 	"context"

--- a/orchestration/cluster_test.go
+++ b/orchestration/cluster_test.go
@@ -1,4 +1,4 @@
-package camunda_test
+package orchestration_test
 
 import (
 	"context"
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sijoma/camunda-go-sdk"
 	"github.com/sijoma/camunda-go-sdk/internal"
+	"github.com/sijoma/camunda-go-sdk/orchestration"
 )
 
 func TestWithCamunda(t *testing.T) {
@@ -22,8 +22,8 @@ func TestWithCamunda(t *testing.T) {
 	camundaURL, err := suite.CamundaEndpoint()
 	require.NoError(t, err)
 	baseURL, _ := url.Parse(camundaURL)
-	c8, err := camunda.NewOrchestrationClusterClient(
-		camunda.WithBaseURL(*baseURL),
+	c8, err := orchestration.NewClient(
+		orchestration.WithBaseURL(*baseURL),
 	)
 	require.NoError(t, err)
 

--- a/orchestration/message.go
+++ b/orchestration/message.go
@@ -1,4 +1,4 @@
-package camunda
+package orchestration
 
 import (
 	"bytes"

--- a/orchestration/message_test.go
+++ b/orchestration/message_test.go
@@ -1,4 +1,4 @@
-package camunda_test
+package orchestration_test
 
 import (
 	"context"
@@ -8,8 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sijoma/camunda-go-sdk"
 	"github.com/sijoma/camunda-go-sdk/internal"
+	"github.com/sijoma/camunda-go-sdk/orchestration"
 )
 
 func Test_Camunda_Message(t *testing.T) {
@@ -22,13 +22,13 @@ func Test_Camunda_Message(t *testing.T) {
 	camundaURL, err := suite.CamundaEndpoint()
 	require.NoError(t, err)
 	baseURL, _ := url.Parse(camundaURL)
-	c8, err := camunda.NewOrchestrationClusterClient(
-		camunda.WithBaseURL(*baseURL),
+	c8, err := orchestration.NewClient(
+		orchestration.WithBaseURL(*baseURL),
 	)
 	require.NoError(t, err)
 
 	t.Run("Publish Message", func(t *testing.T) {
-		resp, err := c8.Message.Publish(t.Context(), camunda.MessagePublishRequest{
+		resp, err := c8.Message.Publish(t.Context(), orchestration.MessagePublishRequest{
 			Name:           "a name",
 			CorrelationKey: "a correlation key",
 			TimeToLive:     0,
@@ -41,7 +41,7 @@ func Test_Camunda_Message(t *testing.T) {
 	})
 
 	t.Run("Correlate Message", func(t *testing.T) {
-		resp, err := c8.Message.Correlate(t.Context(), camunda.MessageCorrelateRequest{
+		resp, err := c8.Message.Correlate(t.Context(), orchestration.MessageCorrelateRequest{
 			Name:           "a name",
 			CorrelationKey: "a correlation key",
 			Variables: map[string]interface{}{


### PR DESCRIPTION
 rename package to `orchestration` and update references SDK and examples

@hamza-m-masood - you will need to rebase your changes a bit after this. It didnt make much sense to have the clients live inside the same structure and package. So I've moved the Orchestration client to its own package. 