### PR TITLE
fix: go.work file does not correclty replace the sdk to the local path

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,9 +1,9 @@
 go 1.24
 
-// This makes sure we use the local client lib for the examples
+replace github.com/sijoma/camunda-go-sdk => ./
+
 use (
-	.
-	examples/orchestration/topology-request
-	examples/orchestration/message
-	examples/management
+	./examples/management
+	./examples/orchestration/message
+	./examples/orchestration/topology-request
 )


### PR DESCRIPTION
With the `go.work` file in the main branch, I get this error:
```
go run ./examples/orchestration/message/main.go
go: conflicting replacements for github.com/sijoma/camunda-go-sdk:
        /Users/hamzamasood/projects/camunda/repos/github/camunda-go-sdk
        /Users/hamzamasood/projects/camunda/repos/github
use "go work edit -replace github.com/sijoma/camunda-go-sdk=[override]" to resolve
```

It is because the SDK is not correctly replace in the go.work file